### PR TITLE
Fix chaining of options

### DIFF
--- a/src/tile38_query.js
+++ b/src/tile38_query.js
@@ -3,7 +3,7 @@
 // simply return arr2
 function addToArray(arr1, arr2) {
   if (arr1) {
-    for (a of arr2) {
+    for (let a of arr2) {
       arr1.push(a);
     }
     return arr1;


### PR DESCRIPTION
Chaining command options (like multiple `where` or `whereIn`) was failing for me because of this variable being undefined. This small change seems to fix it.